### PR TITLE
feat: enable pre-processing to the audio

### DIFF
--- a/WhisperS.Cli/Program.cs
+++ b/WhisperS.Cli/Program.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
+using WhisperS.Core;
+using WhisperS.Core.Audio;
 
 namespace WhisperS.Cli
 {
     internal class Program
     {
-        // whisper.cpp 仓库的根目录
-        private const string DefaultWhisperRoot = "/Users/ptilopsis/Whisper-S/whisper.cpp";
-
-        static int Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             if (args.Length == 0) {
                 Console.WriteLine("Usage: wsub <input-audio-or-video-path>");
@@ -18,101 +18,39 @@ namespace WhisperS.Cli
 
             string inputPath = Path.GetFullPath(args[0]);
 
-            if (!File.Exists(inputPath)) {
-                Console.WriteLine($"Input file not found: {inputPath}");
-                return 1;
+            // 从环境变量读取一些简单配置（后面可以换成正式 CLI 参数）
+            var langEnv = Environment.GetEnvironmentVariable("WSUB_LANG");
+            var coreMlEnv = Environment.GetEnvironmentVariable("WSUB_USE_COREML");
+            var coreMlDecoderEnv = Environment.GetEnvironmentVariable("WSUB_USE_COREML_DECODER");
+            var preprocEnv = Environment.GetEnvironmentVariable("WSUB_ENABLE_PREPROC");
+
+            bool useCoreMl = coreMlEnv == "1" || coreMlEnv == "true";
+            bool useCoreMlDecoder = coreMlDecoderEnv == "1" || coreMlDecoderEnv == "true";
+            bool enablePreproc = preprocEnv == "1" || preprocEnv == "true";
+
+            var preProcessors = new List<IAudioPreProcessor>();
+            if (enablePreproc) {
+                preProcessors.Add(new NormalizePreProcessor());
+                preProcessors.Add(new SimpleFilterPreProcessor());
             }
 
-            string whisperRoot = Environment.GetEnvironmentVariable("WSUB_WHISPER_ROOT")
-                                 ?? DefaultWhisperRoot;
+            var generator = new SubtitleGenerator(
+                language: string.IsNullOrWhiteSpace(langEnv) ? "zh" : langEnv,
+                threads: 8,
+                useCoreMl: useCoreMl,
+                useCoreMlDecoder: useCoreMlDecoder,
+                preProcessors: preProcessors
+            );
 
-            string whisperCliPath = Environment.GetEnvironmentVariable("WSUB_WHISPER_CLI")
-                                    ?? Path.Combine(whisperRoot, "build/bin/whisper-cli");
-
-            string modelPath = Environment.GetEnvironmentVariable("WSUB_WHISPER_MODEL")
-                               ?? Path.Combine(whisperRoot, "models", "ggml-large-v3-turbo.bin");
-
-            string ffmpegPath = "ffmpeg";
-
-            if (!File.Exists(whisperCliPath)) {
-                Console.WriteLine($"whisper-cli not found: {whisperCliPath}");
-                Console.WriteLine("Please check DefaultWhisperRoot or WSUB_WHISPER_CLI.");
-                return 1;
-            }
-
-            if (!File.Exists(modelPath)) {
-                Console.WriteLine($"Model file not found: {modelPath}");
-                Console.WriteLine("Please check WSUB_WHISPER_MODEL or your whisper.cpp models directory.");
-                return 1;
-            }
-
-            string inputDir = Path.GetDirectoryName(inputPath) ?? Directory.GetCurrentDirectory();
-            string fileNameWithoutExt = Path.GetFileNameWithoutExtension(inputPath);
-
-            string tempWav = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.wav");
-            string outputPrefix = Path.Combine(inputDir, fileNameWithoutExt);
-
-            Console.WriteLine($"Input : {inputPath}");
-            Console.WriteLine($"Temp  : {tempWav}");
-            Console.WriteLine($"Output: {outputPrefix}.srt");
-            Console.WriteLine();
+            var progress = new Progress<string>(msg => Console.WriteLine(msg));
 
             try {
-                string ffmpegArgs =
-                    $"-i \"{inputPath}\" -ar 16000 -ac 1 -c:a pcm_s16le \"{tempWav}\"";
-
-                Console.WriteLine("Running ffmpeg...");
-                int ffmpegExit = RunProcess(ffmpegPath, ffmpegArgs);
-                if (ffmpegExit != 0) {
-                    Console.WriteLine($"ffmpeg failed with exit code {ffmpegExit}.");
-                    return ffmpegExit;
-                }
-
-                string whisperArgs =
-                    $"-m \"{modelPath}\" " +
-                    $"-f \"{tempWav}\" " +
-                    $"--output-srt " +
-                    $"-of \"{outputPrefix}\" " +
-                    $"-l zh " +
-                    $"-t 8";
-
-                Console.WriteLine("Running whisper-cli...");
-                int whisperExit = RunProcess(whisperCliPath, whisperArgs);
-                if (whisperExit != 0) {
-                    Console.WriteLine($"whisper-cli failed with exit code {whisperExit}.");
-                    return whisperExit;
-                }
-
-                Console.WriteLine();
-                Console.WriteLine($"Subtitle generated: {outputPrefix}.srt");
+                string srtPath = await generator.GenerateSubtitleAsync(inputPath, progress);
+                Console.WriteLine($"Subtitle generated: {srtPath}");
                 return 0;
-            }
-            finally {
-                if (File.Exists(tempWav)) {
-                    try {
-                        File.Delete(tempWav);
-                    } catch (Exception ex) {
-                        Console.WriteLine($"Warning: failed to delete temp file: {ex.Message}");
-                    }
-                }
-            }
-        }
-
-        private static int RunProcess(string fileName, string arguments)
-        {
-            var psi = new ProcessStartInfo {
-                FileName = fileName,
-                Arguments = arguments,
-                UseShellExecute = false
-            };
-
-            using (var process = Process.Start(psi)) {
-                if (process == null) {
-                    throw new InvalidOperationException($"Failed to start process: {fileName}");
-                }
-
-                process.WaitForExit();
-                return process.ExitCode;
+            } catch (Exception ex) {
+                Console.WriteLine($"Error: {ex.Message}");
+                return 1;
             }
         }
     }

--- a/WhisperS.Cli/WhisperS.Cli.csproj
+++ b/WhisperS.Cli/WhisperS.Cli.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <ItemGroup>
+    <ProjectReference Include="..\WhisperS.Core\WhisperS.Core.csproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/WhisperS.Core/Audio/AudioPreProcessing.cs
+++ b/WhisperS.Core/Audio/AudioPreProcessing.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace WhisperS.Core.Audio
+{
+    public interface IAudioPreProcessor
+    {
+        string Name { get; }
+
+        Task<string> ProcessAsync(string inputWavPath, IProgress<string>? progress = null);
+    }
+
+    // 插件 1：归一化（使用 ffmpeg 的 dynaudnorm）
+    public sealed class NormalizePreProcessor : IAudioPreProcessor
+    {
+        private readonly string _ffmpegPath;
+
+        public NormalizePreProcessor(string ffmpegPath = "ffmpeg")
+        {
+            _ffmpegPath = ffmpegPath;
+        }
+
+        public string Name => "Normalize";
+
+        public async Task<string> ProcessAsync(
+            string inputWavPath,
+            IProgress<string>? progress = null)
+        {
+            string outputWav = Path.Combine(
+                Path.GetTempPath(),
+                $"{Guid.NewGuid():N}_norm.wav");
+
+            string args =
+                $"-y -i \"{inputWavPath}\" " +
+                "-af \"dynaudnorm\" " +
+                "-ar 16000 -ac 1 -c:a pcm_s16le " +
+                $"\"{outputWav}\"";
+
+            int exitCode = await ProcessRunner.RunAsync(_ffmpegPath, args, progress);
+            if (exitCode != 0) {
+                throw new InvalidOperationException(
+                    $"ffmpeg normalize failed with exit code {exitCode}.");
+            }
+
+            return outputWav;
+        }
+    }
+
+    // 插件 2：简单高通 + 低通滤波（滤掉过低和过高频）
+    public sealed class SimpleFilterPreProcessor : IAudioPreProcessor
+    {
+        private readonly string _ffmpegPath;
+
+        public SimpleFilterPreProcessor(string ffmpegPath = "ffmpeg")
+        {
+            _ffmpegPath = ffmpegPath;
+        }
+
+        public string Name => "SimpleFilter";
+
+        public async Task<string> ProcessAsync(
+            string inputWavPath,
+            IProgress<string>? progress = null)
+        {
+            string outputWav = Path.Combine(
+                Path.GetTempPath(),
+                $"{Guid.NewGuid():N}_filt.wav");
+
+            string filter = "highpass=f=100,lowpass=f=8000";
+
+            string args =
+                $"-y -i \"{inputWavPath}\" " +
+                $"-af \"{filter}\" " +
+                "-ar 16000 -ac 1 -c:a pcm_s16le " +
+                $"\"{outputWav}\"";
+
+            int exitCode = await ProcessRunner.RunAsync(_ffmpegPath, args, progress);
+            if (exitCode != 0) {
+                throw new InvalidOperationException(
+                    $"ffmpeg filter failed with exit code {exitCode}.");
+            }
+
+            return outputWav;
+        }
+    }
+}

--- a/WhisperS.Core/ProcessRunner.cs
+++ b/WhisperS.Core/ProcessRunner.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace WhisperS.Core
+{
+    internal static class ProcessRunner
+    {
+        public static Task<int> RunAsync(
+            string fileName,
+            string arguments,
+            IProgress<string>? progress = null)
+        {
+            var tcs = new TaskCompletionSource<int>();
+
+            var psi = new ProcessStartInfo {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            var process = new Process {
+                StartInfo = psi,
+                EnableRaisingEvents = true
+            };
+
+            process.OutputDataReceived += (_, e) => {
+                if (!string.IsNullOrEmpty(e.Data)) {
+                    progress?.Report(e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (_, e) => {
+                if (!string.IsNullOrEmpty(e.Data)) {
+                    progress?.Report(e.Data);
+                }
+            };
+
+            process.Exited += (_, _) => {
+                tcs.TrySetResult(process.ExitCode);
+                process.Dispose();
+            };
+
+            if (!process.Start()) {
+                throw new InvalidOperationException($"Failed to start process: {fileName}");
+            }
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            return tcs.Task;
+        }
+    }
+}

--- a/WhisperS.Core/SubtitleGenerator.cs
+++ b/WhisperS.Core/SubtitleGenerator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using WhisperS.Core.Audio;
 
+// New: enable preprocessor support
 namespace WhisperS.Core
 {
     public class SubtitleGenerator

--- a/WhisperS.Core/SubtitleGenerator.cs
+++ b/WhisperS.Core/SubtitleGenerator.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using WhisperS.Core.Audio;
+
+namespace WhisperS.Core
+{
+    public class SubtitleGenerator
+    {
+        private readonly string _whisperRoot;
+        private readonly string _whisperCliPath;
+        private readonly string _modelPath;
+        private readonly string _ffmpegPath;
+        private readonly string? _language;
+        private readonly int _threads;
+        private readonly bool _useCoreMl;
+        private readonly bool _useCoreMlDecoder;
+        private readonly IReadOnlyList<IAudioPreProcessor> _preProcessors;
+
+        public SubtitleGenerator(
+            string? whisperRoot = null,
+            string? whisperCliPath = null,
+            string? modelPath = null,
+            string ffmpegPath = "ffmpeg",
+            string? language = "zh",
+            int threads = 8,
+            bool useCoreMl = false,
+            bool useCoreMlDecoder = false,
+            IEnumerable<IAudioPreProcessor>? preProcessors = null)
+        {
+            _whisperRoot = whisperRoot
+                            ?? Environment.GetEnvironmentVariable("WSUB_WHISPER_ROOT")
+                            ?? "/Users/ptilopsis/Whisper-S/whisper.cpp";
+
+            _whisperCliPath = whisperCliPath
+                              ?? Environment.GetEnvironmentVariable("WSUB_WHISPER_CLI")
+                              ?? Path.Combine(_whisperRoot, "build/bin/whisper-cli");
+
+            _modelPath = modelPath
+                         ?? Environment.GetEnvironmentVariable("WSUB_WHISPER_MODEL")
+                         ?? Path.Combine(_whisperRoot, "models", "ggml-large-v3-turbo.bin");
+
+            _ffmpegPath = ffmpegPath;
+
+            if (string.IsNullOrWhiteSpace(language) || language == "auto") {
+                _language = null;     // 交给 whisper 自动检测
+            } else {
+                _language = language; // 如 "zh" / "en" / "ja"
+            }
+
+            _threads = threads;
+            _useCoreMl = useCoreMl;
+            _useCoreMlDecoder = useCoreMlDecoder;
+            _preProcessors = (preProcessors != null) ? preProcessors.ToList() : new List<IAudioPreProcessor>();
+        }
+
+        public async Task<string> GenerateSubtitleAsync(
+            string inputPath,
+            IProgress<string>? progress = null)
+        {
+            inputPath = Path.GetFullPath(inputPath);
+
+            if (!File.Exists(inputPath)) {
+                throw new FileNotFoundException("Input file not found", inputPath);
+            }
+
+            if (!File.Exists(_whisperCliPath)) {
+                throw new FileNotFoundException("whisper-cli not found", _whisperCliPath);
+            }
+
+            if (!File.Exists(_modelPath)) {
+                throw new FileNotFoundException("Model file not found", _modelPath);
+            }
+
+            string inputDir = Path.GetDirectoryName(inputPath) ?? Directory.GetCurrentDirectory();
+            string fileNameWithoutExt = Path.GetFileNameWithoutExtension(inputPath);
+
+            string tempWav = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.wav");
+            string processedWav = tempWav;
+            string outputPrefix = Path.Combine(inputDir, fileNameWithoutExt);
+            string outputSrt = outputPrefix + ".srt";
+
+            try {
+                // 1. 原始转码
+                progress?.Report($"[ffmpeg] Converting to wav: {tempWav}");
+
+                string ffmpegArgs =
+                    $"-i \"{inputPath}\" -ar 16000 -ac 1 -c:a pcm_s16le \"{tempWav}\"";
+
+                int ffmpegExit = await ProcessRunner.RunAsync(_ffmpegPath, ffmpegArgs, progress);
+                if (ffmpegExit != 0) {
+                    throw new InvalidOperationException($"ffmpeg failed with exit code {ffmpegExit}.");
+                }
+
+                // 2. 依次执行所有预处理插件
+                foreach (var processor in _preProcessors) {
+                    progress?.Report($"[pre] {processor.Name}...");
+                    processedWav = await processor.ProcessAsync(processedWav, progress);
+                }
+
+                // 3. 构造 whisper-cli 参数
+                string whisperArgs =
+                    $"-m \"{_modelPath}\" " +
+                    $"-f \"{processedWav}\" " +
+                    "--output-srt " +
+                    $"-of \"{outputPrefix}\" " +
+                    $"-t {_threads} ";
+
+                if (!string.IsNullOrEmpty(_language)) {
+                    whisperArgs += $"-l {_language} ";
+                }
+
+                if (_useCoreMl) {
+                    whisperArgs += "--coreml ";
+                }
+
+                if (_useCoreMlDecoder) {
+                    whisperArgs += "--coreml-decoder ";
+                }
+
+                progress?.Report("[whisper] Running whisper-cli...");
+                int whisperExit = await ProcessRunner.RunAsync(_whisperCliPath, whisperArgs, progress);
+                if (whisperExit != 0) {
+                    throw new InvalidOperationException($"whisper-cli failed with exit code {whisperExit}.");
+                }
+
+                progress?.Report($"[done] Subtitle generated: {outputSrt}");
+                return outputSrt;
+            }
+            finally {
+                TryDelete(tempWav);
+                if (processedWav != tempWav) {
+                    TryDelete(processedWav);
+                }
+            }
+        }
+
+        private static void TryDelete(string path)
+        {
+            try {
+                if (File.Exists(path)) {
+                    File.Delete(path);
+                }
+            } catch {
+                // ignore
+            }
+        }
+    }
+}

--- a/WhisperS.Core/WhisperS.Core.csproj
+++ b/WhisperS.Core/WhisperS.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/WhisperS.Core/WhisperS.Core.sln
+++ b/WhisperS.Core/WhisperS.Core.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhisperS.Core", "WhisperS.Core.csproj", "{EE8D7BD8-5CB3-E007-F099-B43A007554A5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EE8D7BD8-5CB3-E007-F099-B43A007554A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE8D7BD8-5CB3-E007-F099-B43A007554A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE8D7BD8-5CB3-E007-F099-B43A007554A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE8D7BD8-5CB3-E007-F099-B43A007554A5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C4693A08-5B71-48DE-A9DC-BF07B1CEA83D}
+	EndGlobalSection
+EndGlobal

--- a/WhisperS.ToolLab/Program.cs
+++ b/WhisperS.ToolLab/Program.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Diagnostics;
+
+class Program {
+    static int Main(string[] args) {
+        Console.WriteLine("Whisper-S Tool Lab");
+        Console.WriteLine("使用 C# 进行一次ffmpeg -version 的调用\n")
+
+        //命令配置
+        var startInfo = new ProcessStartInfo {
+            FileName = "ffmpeg",
+            Arguments = "-version",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExcute = false,
+            CreateNoWindow = true,
+        };
+
+        //创建进程对象
+        using Process process = new Process();
+        process.StartInfo = startInfo;
+
+        try {
+            //启动进程
+            process.Start();
+
+            //读取输出
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+
+        }
+
+    }
+}

--- a/WhisperS.ToolLab/Program.cs
+++ b/WhisperS.ToolLab/Program.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 class Program {
     static int Main(string[] args) {
         Console.WriteLine("Whisper-S Tool Lab");
-        Console.WriteLine("使用 C# 进行一次ffmpeg -version 的调用\n")
+        Console.WriteLine("使用 C# 进行一次ffmpeg -version 的调用\n");
 
         //命令配置
         var startInfo = new ProcessStartInfo {
@@ -28,6 +28,9 @@ class Program {
             string stdout = process.StandardOutput.ReadToEnd();
             string stderr = process.StandardError.ReadToEnd();
 
+        }    catch (Exception ex) {
+            Console.WriteLine("调用 ffmpeg 失败: " + ex.Message);
+            return -1;
         }
 
     }

--- a/WhisperS.ToolLab/WhisperS.ToolLab.csproj
+++ b/WhisperS.ToolLab/WhisperS.ToolLab.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/WhisperS.slnx
+++ b/WhisperS.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="WhisperS.Cli/WhisperS.Cli.csproj" />
+  <Project Path="WhisperS.Core/WhisperS.Core.csproj" />
 </Solution>


### PR DESCRIPTION
调用ffmpeg对原始音频进行预处理，包括低通/高通滤波和归一化，通过本地测试

## Summary by Sourcery

Introduce a reusable core subtitle generation library with optional audio pre-processing and update the CLI to use it asynchronously with environment-based configuration.

New Features:
- Add a core SubtitleGenerator component that orchestrates ffmpeg conversion, optional audio pre-processing, and whisper-cli subtitle generation.
- Introduce pluggable audio pre-processing with normalization and simple high/low-pass filter processors driven by ffmpeg.
- Expose CLI configuration via environment variables for language selection, CoreML options, and enabling audio pre-processing.
- Add a small ToolLab utility project to experiment with invoking ffmpeg from C#.

Enhancements:
- Refactor the CLI entry point to an async workflow that delegates subtitle generation to the shared core library for better reuse and extensibility.

Chores:
- Add new core and tooling projects to the solution to structure shared logic separately from the CLI.